### PR TITLE
fix: Update Dockerfile to use eclipse-temurin:21-jre

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,18 @@
-FROM openjdk:17
+# Use Eclipse Temurin JRE 21 (modern, actively maintained OpenJDK distribution)
+FROM eclipse-temurin:21-jre
 
+# Set working directory
+WORKDIR /app
+
+# Copy the built JAR from the previous stage
 COPY ./build/libs/ancientdata-0.0.1-SNAPSHOT.jar ancientdata.jar
 
+# Expose application port
 EXPOSE 8080
+
+# Health check (optional but recommended)
+HEALTHCHECK --interval=30s --timeout=3s --start-period=5s --retries=3 \
+  CMD java -version || exit 1
+
+# Run the application
 ENTRYPOINT ["java", "-jar", "ancientdata.jar"]


### PR DESCRIPTION
- Replace deprecated openjdk:17 with actively maintained eclipse-temurin:21-jre
- Align JRE version with Gradle toolchain (JDK 21)
- Add WORKDIR directive for better container organization
- Add HEALTHCHECK for container orchestration
- Improve documentation with comments