### PR TITLE
fix: Add artifact upload/download between build and docker jobs

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -34,6 +34,13 @@ jobs:
       - name: Build with Gradle
         run: ./gradlew clean build -x test
 
+      - name: Upload build artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: gradle-build
+          path: build/libs/
+          retention-days: 1
+
       - name: Get the version
         id: vars
         run: echo "tag=${GITHUB_SHA::10}" >> "$GITHUB_OUTPUT"
@@ -47,6 +54,12 @@ jobs:
       - uses: actions/checkout@v5
         with:
           fetch-depth: 0
+
+      - name: Download build artifacts
+        uses: actions/download-artifact@v4
+        with:
+          name: gradle-build
+          path: build/libs/
 
       - name: Docker login
         env:


### PR DESCRIPTION
The docker job was running without the compiled JAR from the build job.
- Add upload-artifact step in build job to preserve build/libs/ directory
- Add download-artifact step in docker job to restore the JAR before Docker build
- Set 1-day retention to minimize storage usage
- Ensures Docker build has the ancientdata-0.0.1-SNAPSHOT.jar file