### PR TITLE
fix: Upgrade artifact actions to v5 for Node.js 24 compatibility

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -56,7 +56,7 @@ jobs:
           fetch-depth: 0
 
       - name: Download build artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v5
         with:
           name: gradle-build
           path: build/libs/


### PR DESCRIPTION
- Upgrade actions/upload-artifact from v4 to v5 (Node.js 24 ready)
- Upgrade actions/download-artifact from v4 to v5 (Node.js 24 ready)
- Eliminates deprecation warnings about Node.js 20